### PR TITLE
Add new message: node/{id}/battery/{type}/percentage

### DIFF
--- a/app/application.c
+++ b/app/application.c
@@ -231,14 +231,11 @@ void bc_radio_on_co2(uint64_t *peer_device_address, float *concentration)
     usb_talk_publish_co2_concentation(peer_device_address, concentration);
 }
 
-void bc_radio_on_battery(uint64_t *peer_device_address, uint8_t *format, float *voltage)
+void bc_radio_on_battery(uint64_t *peer_device_address, uint8_t *format, float *voltage, float *percentage)
 {
     bc_led_pulse(&led, 10);
 
-    usb_talk_send_format("[\"%012llx/battery/%s/voltage\", %.2f]\n",
-            *peer_device_address,
-            *format == 0 ? "standard" : "mini",
-            *voltage);
+    usb_talk_publish_battery(peer_device_address, format, voltage, percentage);
 }
 
 void bc_radio_on_buffer(uint64_t *peer_device_address, uint8_t *buffer, size_t *length)

--- a/app/usb_talk.c
+++ b/app/usb_talk.c
@@ -290,6 +290,21 @@ void usb_talk_publish_barometer(uint64_t *device_address, uint8_t *i2c, float *p
     usb_talk_send_string((const char *) _usb_talk.tx_buffer);
 }
 
+void usb_talk_publish_battery(uint64_t *device_address, uint8_t *format, float *voltage, float *percentage)
+{
+    snprintf(_usb_talk.tx_buffer, sizeof(_usb_talk.tx_buffer),
+                "[\"%012llx/battery/%s/voltage\", %.2f]\n",
+                *device_address, (*format == 0 ? "standard" : "mini"), *voltage);
+
+    usb_talk_send_string((const char *) _usb_talk.tx_buffer);
+
+    snprintf(_usb_talk.tx_buffer, sizeof(_usb_talk.tx_buffer),
+                "[\"%012llx/battery/%s/percentage\", %.0f]\n",
+                *device_address, (*format == 0 ? "standard" : "mini"), *percentage);
+
+    usb_talk_send_string((const char *) _usb_talk.tx_buffer);
+}
+
 void usb_talk_publish_co2_concentation(uint64_t *device_address, float *concentration)
 {
     snprintf(_usb_talk.tx_buffer, sizeof(_usb_talk.tx_buffer),

--- a/app/usb_talk.h
+++ b/app/usb_talk.h
@@ -46,6 +46,7 @@ void usb_talk_publish_humidity_sensor(uint64_t *device_address, uint8_t *i2c, fl
 void usb_talk_publish_lux_meter(uint64_t *device_address, uint8_t *i2c, float *illuminance);
 void usb_talk_publish_barometer(uint64_t *device_address, uint8_t *i2c, float *pascal, float *altitude);
 void usb_talk_publish_co2_concentation(uint64_t *device_address, float *concentration);
+void usb_talk_publish_battery(uint64_t *device_address, uint8_t *format, float *voltage, float *percentage);
 void usb_talk_publish_light(uint64_t *device_address, bool *state);
 void usb_talk_publish_relay(uint64_t *device_address, bool *state);
 void usb_talk_publish_module_relay(uint64_t *device_address, uint8_t *number, bc_module_relay_state_t *state);


### PR DESCRIPTION
This change expect battery voltage and percentage in radio message and publish two battery messages to usb.

original: `node/{id}/battery/{type}/voltage`
and new: `node/{id}/battery/{type}/percentage`

![obrazek](https://user-images.githubusercontent.com/155542/32573561-b855f7be-c4ce-11e7-9f1c-32d606ef029d.png)

Please note, that this change needs updated SDK module: https://github.com/bigclownlabs/bcf-sdk/pull/143